### PR TITLE
fix: make FormText a <span> instead of <p> to remove default padding

### DIFF
--- a/src/bootstrap/BsFormText/index.tsx
+++ b/src/bootstrap/BsFormText/index.tsx
@@ -6,8 +6,8 @@ export const BsFormText: FC<HelpTextComponentProps> = ({
   children,
 }) => {
   return (
-    <p className="form-text" aria-describedby={ariaDescribedBy}>
+    <span className="form-text" aria-describedby={ariaDescribedBy}>
       {children}
-    </p>
+    </span>
   );
 };


### PR DESCRIPTION
Also <p> seems like the wrong tag to use semantically. Form text is not a paragraph.